### PR TITLE
generics: add TS bounds when deriving TS

### DIFF
--- a/ts-rs/tests/generic_struct.rs
+++ b/ts-rs/tests/generic_struct.rs
@@ -13,6 +13,20 @@ where
 }
 
 #[derive(TS)]
+struct GenericAutoBound<T> {
+    value: T,
+    values: Vec<T>,
+}
+
+#[derive(TS)]
+struct GenericAutoBound2<T>
+where T: PartialEq
+{
+    value: T,
+    values: Vec<T>,
+}
+
+#[derive(TS)]
 struct Container {
     foo: Generic<u32>,
     bar: Vec<Generic<u32>>,
@@ -25,6 +39,24 @@ fn test() {
         Generic::<()>::decl(),
         "\
 interface Generic<T> {
+    value: T,
+    values: Array<T>,
+}"
+    );
+
+    assert_eq!(
+        GenericAutoBound::<()>::decl(),
+        "\
+interface GenericAutoBound<T> {
+    value: T,
+    values: Array<T>,
+}"
+    );
+
+    assert_eq!(
+        GenericAutoBound2::<()>::decl(),
+        "\
+interface GenericAutoBound2<T> {
     value: T,
     values: Array<T>,
 }"


### PR DESCRIPTION
Cleaned up the commit mentioned in https://github.com/Aleph-Alpha/ts-rs/pull/25

It now also work for cases when the struct already has trait bounds, but TS is not one of the bounds:

```rust
#[derive(TS)]
struct GenericAutoBound2<T>
where T: PartialEq
{
    value: T,
    values: Vec<T>,
}
```